### PR TITLE
Add some XONLINE declarations

### DIFF
--- a/include/xboxdef.h
+++ b/include/xboxdef.h
@@ -32,6 +32,7 @@ typedef ULONG_PTR SIZE_T, *PSIZE_T;
 
 typedef int BOOL, *PBOOL;
 typedef const char *PCSZ, *PCSTR, *LPCSTR;
+typedef WCHAR *LPWSTR;
 
 
 

--- a/include/xonline.h
+++ b/include/xonline.h
@@ -25,6 +25,7 @@
 #ifndef XONLINE_H
 #define XONLINE_H
 
+#include "xboxdef.h"
 #include "xapi.h" // For EMUPATCH
 
 typedef struct _WSADATA {
@@ -112,22 +113,124 @@ int WINAPI EMUPATCH(recv)
 
 int WINAPI EMUPATCH(bind)
 (
-    SOCKET s, 
-    const struct sockaddr *name, 
+    SOCKET s,
+    const struct sockaddr *name,
     int namelen
 );
 
 int WINAPI EMUPATCH(listen)
 (
-    SOCKET s, 
+    SOCKET s,
     int backlog
 );
 
 int WINAPI EMUPATCH(ioctlsocket)
 (
-    SOCKET s, 
-    long cmd, 
+    SOCKET s,
+    long cmd,
     u_long *argp
+);
+
+typedef struct _XNKID
+{
+    BYTE ab[8];
+} XNKID;
+
+typedef struct _XNKEY
+{
+    BYTE ab[16];
+} XNKEY;
+
+typedef struct _IN_ADDR
+{
+    union
+    {
+        struct
+        {
+            UCHAR s_b1;
+            UCHAR s_b2;
+            UCHAR s_b3;
+            UCHAR s_b4;
+        } S_un_b;
+        struct
+        {
+            USHORT s_w1;
+            USHORT s_w2;
+        } S_un_w;
+        ULONG S_addr;
+    } S_un;
+} IN_ADDR;
+
+typedef struct _XNADDR
+{
+    IN_ADDR ina;
+    IN_ADDR inaOnline;
+    WORD wPortOnline;
+    BYTE abEnet[6];
+    BYTE abOnline[20];
+} XNADDR;
+
+typedef struct _XONLINE_MATCH_SEARCHRESULT
+{
+    DWORD dwReserved;
+    XNKID SessionID;
+    XNADDR HostAddress;
+    XNKEY KeyExchangeKey;
+    DWORD dwPublicOpen;
+    DWORD dwPrivateOpen;
+    DWORD dwPublicFilled;
+    DWORD dwPrivateFilled;
+    DWORD dwNumAttributes;
+} XONLINE_MATCH_SEARCHRESULT, *PXONLINE_MATCH_SEARCHRESULT;
+
+typedef struct _XONLINE_ATTRIBUTE {
+    DWORD dwAttributeID;
+    BOOL fChanged;
+    union {
+        struct {
+            ULONGLONG qwValue;
+        } integer;
+        struct {
+            LPWSTR lpValue;
+        } string;
+        struct {
+            PVOID pvValue;
+            DWORD dwLength;
+        } blob;
+    } info;
+} XONLINE_ATTRIBUTE, *PXONLINE_ATTRIBUTE;
+
+typedef HANDLE XONLINETASK_HANDLE, *PXONLINETASK_HANDLE;
+
+typedef struct _XONLINE_ATTRIBUTE_SPEC
+{
+    DWORD dwType;
+    DWORD dwLength;
+ } XONLINE_ATTRIBUTE_SPEC, *PXONLINE_ATTRIBUTE_SPEC;
+
+HRESULT WINAPI XOnlineMatchSearch
+(
+    IN DWORD dwProcedureIndex,
+    IN DWORD dwNumResults,
+    IN DWORD dwNumAttributes,
+    IN const XONLINE_ATTRIBUTE *pAttributes,
+    IN DWORD dwResultsLen,
+    IN OPTIONAL HANDLE hWorkEvent,
+    OUT PXONLINETASK_HANDLE phTask
+);
+
+DWORD WINAPI XOnlineMatchSearchResultsLen
+(
+    IN DWORD dwNumResults,
+    IN DWORD dwNumSessionAttributes,
+    IN const XONLINE_ATTRIBUTE_SPEC *pSessionAttributeSpec
+);
+
+HRESULT WINAPI XOnlineMatchSearchGetResults
+(
+    IN XONLINETASK_HANDLE hTask,
+    OUT PXONLINE_MATCH_SEARCHRESULT **prgpSearchResults,
+    OUT DWORD *pdwReturnedResults
 );
 
 #endif


### PR DESCRIPTION
This adds some XONLINE declarations that are helpful for reverse-engineering XBL matchmaking queries.